### PR TITLE
Rbd nbd

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -407,12 +407,13 @@ func (util *RBDUtil) DetachDisk(plugin *rbdPlugin, deviceMountPath string, devic
 	exec := plugin.host.GetExec(plugin.GetPluginName())
 
 	var rbdCmd string
-	if _, err := exec.Run("rbd-nbd", "version"); err == nil {
+
+	// Unlike map, we cannot fallthrough for unmap
+	// the tool to unmap is based on device type
+	if strings.HasPrefix(device, "/dev/nbd") {
 		rbdCmd = "rbd-nbd"
-		glog.V(4).Infof("rbd: using rbd-nbd for unmap function")
 	} else {
 		rbdCmd = "rbd"
-		glog.V(4).Infof("rbd: using rbd for unmap function")
 	}
 
 	// rbd unmap

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -333,10 +333,10 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 	var devicePath string
 	var mapped bool
 	if nbdToolsFound {
-		devicePath, mapped = waitForPath(b.Pool, b.Image /*maxRetries*/, 1 /*useNbdDriver*/, true)
+		devicePath, mapped = waitForPath(b.Pool, b.Image, 1 /*maxRetries*/, true /*useNbdDriver*/)
 	}
 	if !mapped {
-		devicePath, mapped = waitForPath(b.Pool, b.Image /*maxRetries*/, 1 /*useNbdDriver*/, false)
+		devicePath, mapped = waitForPath(b.Pool, b.Image, 1 /*maxRetries*/, false /*useNbdDriver*/)
 	}
 
 	if !mapped {
@@ -374,7 +374,7 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 				glog.Infof("rbd-nbd: map error %v, rbd-nbd output: %s", err, string(output))
 				glog.V(4).Info("will retry using rbd after rbd-nbd failure")
 			} else {
-				devicePath, mapped = waitForPath(b.Pool, b.Image /*maxRetries*/, 10 /*useNbdDriver*/, true)
+				devicePath, mapped = waitForPath(b.Pool, b.Image, 10 /*maxRetries*/, true /*useNbdDriver*/)
 			}
 		}
 		if !mapped {
@@ -387,7 +387,7 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) (string, error) {
 				glog.V(1).Infof("rbd: map error %v, rbd output: %s", err, string(output))
 				return "", fmt.Errorf("rbd: map failed %v, rbd output: %s", err, string(output))
 			}
-			devicePath, mapped = waitForPath(b.Pool, b.Image /*maxRetries*/, 10 /*useNbdDriver*/, false)
+			devicePath, mapped = waitForPath(b.Pool, b.Image, 10 /*maxRetries*/, false /*useNbdDriver*/)
 		}
 		if !mapped {
 			return "", fmt.Errorf("Could not map image %s/%s, Timeout after 10s", b.Pool, b.Image)


### PR DESCRIPTION
rbd-nbd accepts only fully qualified name for non-default pools. This pr also get rids of check for rbd tools during check for tools during unmap. If we have to add it back, the command is rbd-nbd --version (rbd-nbd version).